### PR TITLE
PTX-10950: kubelet fails to come up after node reboot on a kubespray deployed env

### DIFF
--- a/roles/container-engine/cri-dockerd/handlers/main.yml
+++ b/roles/container-engine/cri-dockerd/handlers/main.yml
@@ -9,8 +9,9 @@
 - name: cri-dockerd | reload systemd
   systemd:
     name: cri-dockerd
-    daemon_reload: true
+    daemon_reload: yes
     masked: no
+    enabled: yes
 
 - name: cri-dockerd | reload cri-dockerd.socket
   service:


### PR DESCRIPTION
Possible fix for kubelet failing to come up after node reboot on a kubespray deployed env.